### PR TITLE
lua-ue4 pipeline build

### DIFF
--- a/lua-ue4/android/Jenkinsfile
+++ b/lua-ue4/android/Jenkinsfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/lua-ue4.git'
+
+pipeline {
+    agent {
+        label "ubuntu:16.04 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'LUA_UE4_VERSION',
+            defaultValue: '5.3.5')
+    }
+    environment {
+        LUA_UE4_VERSION             = "${params.LUA_UE4_VERSION}"
+        LUA_UE4_PREFIX              = "${env.HOME}/thirdparty/lua-ue4/${params.LUA_UE4_VERSION}"
+        LUA_UE4_ZIP                 = "lua-ue4-${params.LUA_UE4_VERSION}-android.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    sh './Build_Android.sh'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.LUA_UE4_PREFIX, zipFile: env.LUA_UE4_ZIP
+            }
+        }
+    }
+}

--- a/lua-ue4/ios/Jenkinsfile
+++ b/lua-ue4/ios/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/lua-ue4.git'
+
+pipeline {
+    agent {
+        label "os:mac && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'LUA_UE4_VERSION',
+            defaultValue: '5.3.5')
+    }
+    environment {
+        LUA_UE4_VERSION             = "${params.LUA_UE4_VERSION}"
+        LUA_UE4_PREFIX              = "${env.HOME}/thirdparty/lua-ue4/${params.LUA_UE4_VERSION}"
+        LUA_UE4_ZIP                 = "lua-ue4-${params.LUA_UE4_VERSION}-ios.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                sh './Build_IOS.sh'
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.LUA_UE4_PREFIX, zipFile: env.LUA_UE4_ZIP
+            }
+        }
+    }
+}

--- a/lua-ue4/linux/Jenkinsfile
+++ b/lua-ue4/linux/Jenkinsfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/lua-ue4.git'
+
+pipeline {
+    agent {
+        label "ubuntu:16.04 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'LUA_UE4_VERSION',
+            defaultValue: '5.3.5')
+    }
+    environment {
+        LUA_UE4_VERSION             = "${params.LUA_UE4_VERSION}"
+        LUA_UE4_PREFIX              = "${env.HOME}/thirdparty/lua-ue4/${params.LUA_UE4_VERSION}"
+        LUA_UE4_ZIP                 = "lua-ue4-${params.LUA_UE4_VERSION}-linux.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    sh './Build_Linux.sh'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.LUA_UE4_PREFIX, zipFile: env.LUA_UE4_ZIP
+            }
+        }
+    }
+}

--- a/lua-ue4/mac/Jenkinsfile
+++ b/lua-ue4/mac/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/lua-ue4.git'
+
+pipeline {
+    agent {
+        label "os:mac && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'LUA_UE4_VERSION',
+            defaultValue: '5.3.5')
+    }
+    environment {
+        LUA_UE4_VERSION             = "${params.LUA_UE4_VERSION}"
+        LUA_UE4_PREFIX              = "${env.HOME}/thirdparty/lua-ue4/${params.LUA_UE4_VERSION}"
+        LUA_UE4_ZIP                 = "lua-ue4-${params.LUA_UE4_VERSION}-mac.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                sh './Build_Mac.sh'
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.LUA_UE4_PREFIX, zipFile: env.LUA_UE4_ZIP
+            }
+        }
+    }
+}

--- a/lua-ue4/windows/Jenkinsfile
+++ b/lua-ue4/windows/Jenkinsfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/lua-ue4.git'
+
+pipeline {
+    agent {
+        label "windows:10 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'LUA_UE4_VERSION',
+            defaultValue: '5.3.5')
+    }
+    environment {
+        LUA_UE4_VERSION             = "${params.LUA_UE4_VERSION}"
+        LUA_UE4_PREFIX              = "${env.WORKSPACE}\\third-party\\lua-ue4\\${params.LUA_UE4_VERSION}"
+        LUA_UE4_ZIP                 = "lua-ue4-${params.LUA_UE4_VERSION}-windows.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    bat 'Build_Windows.bat'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.LUA_UE4_PREFIX, zipFile: env.LUA_UE4_ZIP
+            }
+        }
+    }
+}


### PR DESCRIPTION
lua-ue4 pipeline build

(1) 实现方法
通过在官网下载lua源码，脚本修改luaconf.h文件后编译实现

(2) 平台选项 
   平台           编译选项
windows          64
linux                64
mac                 64
ios                   arm64
android           armeabi-v7a
注：android平台，现在客户端打包选项是armeabi-v7a

(3) 编译脚本仓库
临时打包脚本仓库:  https://github.com/yanzhubiao/lua-ue4.git

(4) 测试
测试路径: https://jenkins.intranet.rog2.org/job/Personal/job/yanzhubiao/job/lua_ue4_pipeline/

第二次提交内容：

(1)
windows平台增加 liblua_a.lib
linux平台增加 liblua.so
mac平台增加 liblua.dylib

(2)  android在linux下编译

(3)  使用powershell解压tar.gz文件

(4)  删除script文件夹