### PR TITLE
Add Jenkinsfiles for protobuf-ue4

### DIFF
--- a/protobuf-ue4/android/Jenkinsfile
+++ b/protobuf-ue4/android/Jenkinsfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/protobuf-ue4.git'
+
+pipeline {
+    agent {
+        label "ubuntu:16.04 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'PROTOBUF_UE4_VERSION',
+            defaultValue: '3.6.1')
+    }
+    environment {
+        PROTOBUF_UE4_VERSION             = "${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_PREFIX              = "${env.HOME}/thirdparty/protobuf-ue4/${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_ZIP                 = "protobuf-ue4-${params.PROTOBUF_UE4_VERSION}-android.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    sh './Build_Android.sh'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.PROTOBUF_UE4_PREFIX, zipFile: env.PROTOBUF_UE4_ZIP
+            }
+        }
+    }
+}

--- a/protobuf-ue4/ios/Jenkinsfile
+++ b/protobuf-ue4/ios/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/protobuf-ue4.git'
+
+pipeline {
+    agent {
+        label "os:mac && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'PROTOBUF_UE4_VERSION',
+            defaultValue: '3.6.1')
+    }
+    environment {
+        PROTOBUF_UE4_VERSION             = "${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_PREFIX              = "${env.HOME}/thirdparty/protobuf-ue4/${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_ZIP                 = "protobuf-ue4-${params.PROTOBUF_UE4_VERSION}-ios.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                sh './Build_IOS.sh'
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.PROTOBUF_UE4_PREFIX, zipFile: env.PROTOBUF_UE4_ZIP
+            }
+        }
+    }
+}

--- a/protobuf-ue4/linux/Jenkinsfile
+++ b/protobuf-ue4/linux/Jenkinsfile
@@ -1,0 +1,77 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/protobuf-ue4.git'
+
+ENGINE_LOCAL_DIR = 'UnrealEngine'
+ENGINE_SYS = 'Linux'
+
+pipeline {
+    agent {
+        label "ubuntu:16.04 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'PROTOBUF_UE4_VERSION',
+            defaultValue: '3.6.1')
+        booleanParam(name: 'CLEAN_WS',
+            defaultValue: false,
+            description: 'When checked, call function cleanWs.')
+    }
+    environment {
+        PROTOBUF_UE4_WORKSPACE           = "${env.WORKSPACE}"
+        UE4_ROOT                         = "${env.WORKSPACE}/UnrealEngine"
+        PROTOBUF_UE4_VERSION             = "${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_PREFIX              = "${env.HOME}/thirdparty/protobuf-ue4/${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_ZIP                 = "protobuf-ue4-${params.PROTOBUF_UE4_VERSION}-linux.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                script {
+                    if (params.CLEAN_WS) {
+                        cleanWs()
+                    }
+                }
+            }
+        }
+
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+
+        stage('Git Engine') {
+            steps {
+                script {
+                    def ue4CleanBuild = !fileExists(ENGINE_LOCAL_DIR)
+                    if (ue4CleanBuild) {
+                        buildEngine.ue4Checkout(ENGINE_LOCAL_DIR, ENGINE_SYS)
+                        dir(ENGINE_LOCAL_DIR) {
+                            sh './ResumeGitDep.sh'                 
+                        }
+                    } 
+                }
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    sh 'rm -rf *.zip'
+                    sh './Build_Linux.sh'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.PROTOBUF_UE4_PREFIX, zipFile: env.PROTOBUF_UE4_ZIP
+            }
+        }
+    }
+}

--- a/protobuf-ue4/linux/Jenkinsfile
+++ b/protobuf-ue4/linux/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                     if (ue4CleanBuild) {
                         buildEngine.ue4Checkout(ENGINE_LOCAL_DIR, ENGINE_SYS)
                         dir(ENGINE_LOCAL_DIR) {
-                            sh './ResumeGitDep.sh'                 
+                            buildEngine.ue4Setup(ENGINE_SYS, '')               
                         }
                     } 
                 }

--- a/protobuf-ue4/mac/Jenkinsfile
+++ b/protobuf-ue4/mac/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/protobuf-ue4.git'
+
+pipeline {
+    agent {
+        label "os:mac && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'PROTOBUF_UE4_VERSION',
+            defaultValue: '3.6.1')
+    }
+    environment {
+        PROTOBUF_UE4_VERSION             = "${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_PREFIX              = "${env.HOME}/thirdparty/protobuf-ue4/${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_ZIP                 = "protobuf-ue4-${params.PROTOBUF_UE4_VERSION}-mac.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                sh './Build_Mac.sh'
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.PROTOBUF_UE4_PREFIX, zipFile: env.PROTOBUF_UE4_ZIP
+            }
+        }
+    }
+}

--- a/protobuf-ue4/windows/Jenkinsfile
+++ b/protobuf-ue4/windows/Jenkinsfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+def gitRepo = 'https://github.com/rog2/protobuf-ue4.git'
+
+pipeline {
+    agent {
+        label "windows:10 && thirdparty"
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    parameters {
+        string(name: 'PROTOBUF_UE4_VERSION',
+            defaultValue: '3.6.1')
+    }
+    environment {
+        PROTOBUF_UE4_VERSION             = "${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_PREFIX              = "${env.WORKSPACE}\\third-party\\protobuf-ue4\\${params.PROTOBUF_UE4_VERSION}"
+        PROTOBUF_UE4_ZIP                 = "protobuf-ue4-${params.PROTOBUF_UE4_VERSION}-windows.zip"
+
+    }
+    stages {
+        stage('Cleanup') {
+            steps {
+                cleanWs()
+            }
+        }
+        
+        stage('Download') {
+            steps {
+                git gitRepo
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                withCMake("3.10.1")
+                {
+                    bat 'Build_Windows.bat'
+                }
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                zip archive: true, dir: env.PROTOBUF_UE4_PREFIX, zipFile: env.PROTOBUF_UE4_ZIP
+            }
+        }
+    }
+}


### PR DESCRIPTION
（1）protobuf-ue4仓库
功能：编译libprotobuf
url : https://github.com/yanzhubiao/protobuf-ue4

（2）protobuf-ue4 Jenkins Pipeline
功能：编译libprotobuf的jenkins pipeline
url : https://jenkins.intranet.rog2.org/job/Personal/job/yanzhubiao/job/protobuf-ue4/

（3）protobuf-ue4-test  Jenkins Pipeline
功能：构建windows_client、android_client(ubuntu、mac系统)、linux_dungeon_server
url ：https://jenkins.intranet.rog2.org/job/Personal/job/yanzhubiao/job/protobuf-ue4-test/

测试环境：
（a）通过windows editor启动client、dungeon server
（b）windows安装包启动client、ubuntu下启动dungeon server
（c）ubuntu下打包的android安装包启动client
（d）mac下打包的android安装包启动client

测试内容：
（a）创建新角色，做任务到出海   
（b）gm加船只、经验后，进入竞技场、吃鸡副本、战场

注：在windows平台下，如果同时存在vs2017与vs2015,ue4-4.20会选择vs2017的toolchain,所以不会有编译问题。